### PR TITLE
Fix 'Could not load colour scheme' error message

### DIFF
--- a/sbs_compare.py
+++ b/sbs_compare.py
@@ -159,7 +159,7 @@ class SbsCompareCommand( sublime_plugin.TextCommand ):
 		# generate modified theme
 		if generate:
 			# load current scheme
-			current_scheme = view.settings().get( 'color_scheme' )  # no 'u' >:(
+			current_scheme = self.get_current_color_scheme( view )
 			try:
 				scheme = sublime.load_resource( current_scheme )
 			except:
@@ -223,6 +223,21 @@ class SbsCompareCommand( sublime_plugin.TextCommand ):
 		# set view settings to use new theme
 		view.settings().set( 'color_scheme', self.last_theme_file )
 		return colourStrings
+
+	def get_current_color_scheme( self, view ):
+		current_scheme = view.settings().get( 'color_scheme' )  # no 'u' >:(
+
+		packages_path = os.path.basename( sublime.packages_path() )
+
+		# The default 'color_scheme' setting only has the file name
+		# and it's inside the 'Color Scheme - Default' package.
+		if not current_scheme.startswith(packages_path + '/'):
+			rel_current_scheme_file = os.path.join( packages_path, 'Color Scheme - Default', current_scheme )
+			rel_current_scheme_file = rel_current_scheme_file.replace( '\\', '/' )
+
+			current_scheme = rel_current_scheme_file
+
+		return current_scheme
 
 	def get_view_contents( self, view ):
 		selection = sublime.Region( 0, view.size() )


### PR DESCRIPTION
At least in MacOS, the default `color_scheme` Preference is set like this:
```json
  "color_scheme": "Monokai.sublime-color-scheme"
```
![image](https://user-images.githubusercontent.com/1738654/59554606-de030500-8f7b-11e9-8a6a-a5a1974d1be7.png)


It lacks of the `Packages/Color Scheme - Default/` package path. Given that, when `load_resource()` is called it can't load it and falls back to a blank color scheme.

The provided solution prepends the said package path to the value obtained from the settings when it does not start with `Packages/`.

See also related issue #31